### PR TITLE
remove peerDependencies, it was blocking use with updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-systemjs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A Karma plugin.  Adapter for SystemJS module loader.",
   "main": "lib/index.js",
   "scripts": {
@@ -16,6 +16,7 @@
     "systemjs"
   ],
   "author": "Jason Stone <rolaveric@gmail.com>",
+  "contributors": "Kendrick Burson <spam.kpb@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rolaveric/karma-systemjs/issues"
@@ -26,16 +27,10 @@
     "es6-module-loader": "^0.11.2",
     "jasmine-core": "^2.1.3",
     "jasmine-node": "^1.14.5",
-    "karma": ">=0.9",
+    "karma": ">=0.9.0",
     "karma-firefox-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.4",
     "systemjs": "^0.11.2",
-    "traceur": "0.0.81"
-  },
-  "peerDependencies": {
-    "karma": ">=0.9",
-    "systemjs": "~0.11.2",
-    "es6-module-loader": "~0.11.2",
-    "traceur": "~0.0.79"
+    "traceur": "^0.0.81"
   }
 }


### PR DESCRIPTION
peerDependencies are deprecated in npm and will be removed in npm 3.0, so do not depend on them now.