### PR TITLE
Add option to omit using a transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 
 # Installation
 
-karma-systemjs requires SystemJS, es6-module-loader, and Traceur to be installed too.
+karma-systemjs requires SystemJS and es6-module-loader to be installed.
 
-`npm install karma-systemjs systemjs es6-module-loader traceur`
+`npm install karma-systemjs systemjs es6-module-loader`
+
+If using a transpiler, be sure to install it too. Traceur and Babel are supported:
+
+`npm install traceur`
+
+`npm install babel`
 
 # Karma Configuration
 
@@ -59,6 +65,18 @@ systemjs: {
 	]
 }
 ```
+
+karma-systemjs defaults to using Traceur as transpiler. To use Babel, add the following to the SystemJS configuration:
+
+```js
+systemjs: {
+	config: {
+		transpiler: 'babel'
+	}
+}
+```
+
+The transpiler can also be omitted by setting `transpiler` to `null`.
 
 # Examples
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,19 +87,29 @@ var initSystemjs = function (config) {
 		mergeConfigs(readConfigFile(cfgPath), systemjsConfig.config);
 	}
 
-	var transpilerPath = systemjsConfig.config.transpiler === 'babel' ?
-		getDependencyPath('babel', '/../../../browser.js') :
-		getDependencyPath('traceur', '/../../bin/traceur.js');
 	var es6ModuleLoaderPath = getDependencyPath('es6-module-loader', '/../dist/es6-module-loader.src.js');
 	var systemjsPath = getDependencyPath('systemjs', '/system.src.js');
 
-	// Adds dependencies to start of config.files: traceur, es6-module-loader, and system.js
+	// Adds dependencies to start of config.files: es6-module-loader, and system.js
 	// Don't watch, since these files should never change
 	config.files.unshift(
-		createIncludePattern(transpilerPath),
 		createIncludePattern(es6ModuleLoaderPath),
 		createIncludePattern(systemjsPath)
 	);
+
+	// Default to use Traceur as transpiler, but make it possible to avoid using
+	// a transpiler by setting the transpiler option to null.
+	var useTranspiler = systemjsConfig.config.transpiler !== null;
+	if (useTranspiler) {
+		var transpilerPath = systemjsConfig.config.transpiler === 'babel' ?
+			getDependencyPath('babel', '/../../../browser.js') :
+			getDependencyPath('traceur', '/../../bin/traceur.js');
+
+		// Don't watch, since this file should never change
+		config.files.unshift(
+			createIncludePattern(transpilerPath)
+		);
+	}
 
 	// Adds file patterns from config.systemjs.files to config.files, set to be served but not included
 	if (systemjsConfig.files) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -26,6 +26,13 @@ describe('initSystemJs', function () {
     expect(config.files[2].pattern).toMatch(/\/system\.src\.js$/);
   });
 
+	it('Omits adding a file pattern for a transpiler if the transpiler option is set to null', function () {
+		config.systemjs.config = {transpiler: null};
+		initSystemJs(config);
+		expect(config.files[0].pattern).toMatch(/\/es6-module-loader\.src\.js$/);
+		expect(config.files[1].pattern).toMatch(/\/system\.src\.js$/);
+	});
+
 	it('Adds file pattern for the SystemJS config file, after the SystemJS libraries', function () {
 		config.systemjs.configFile = 'test/system.conf.js';
 		initSystemJs(config);


### PR DESCRIPTION
If the source code is transpiled by the build script, it makes sense to reuse the transpiled code for unit tests. This PR adds an option to explictly omit using a transpiler by setting the transpiler option to null in the SystemJS configuration override. Backwards compatibility is maintained by defaulting to Traceur as transpiler.