### PR TITLE
Fix disconnect on failed imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+node_modules

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -54,6 +54,8 @@
 			// Once all imports are complete...
 			Promise.all(testSuitePromises).then(function () {
 				karma.start();
+			}, function (e) {
+				karma.error(e);
 			});
 		}
 	};


### PR DESCRIPTION
If trying to import a non-existent file, `karma.start()` will never get called, and karma disconnects after a given timeout (10 seconds), blocking subsequent test runs:
```
WARN [web-server]: 404: /base/x.js
PhantomJS 1.9.8 (Linux) ERROR: 'Potentially unhandled rejection [4] Error loading "foo" at http://localhost:8032/base/foo.js
Error loading "foo" from "bar.spec" at http://localhost:8032/base/bar.spec.js
Not Found: http://localhost:8032/base/foo.js (WARNING: non-Error used)'
WARN [PhantomJS 1.9.8 (Linux)]: Disconnected (1 times), because no message in 10000 ms.
PhantomJS 1.9.8 (Linux): Executed 0 of 0 DISCONNECTED (10.098 secs / 0 secs)
```
This PR calls `karma.error()` to correctly handle failed imports.

Also add node_modules to `.gitignore`.