### PR TITLE
Add polyfill to make SystemJS >= v0.16 work with PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ karma-systemjs requires SystemJS and es6-module-loader to be installed.
 
 `npm install karma-systemjs systemjs es6-module-loader`
 
+If testing in PhantomJS, you must install phantomjs-polyfill, as SystemJS >= v0.16 uses `Function.prototype.bind()`.
+
+`npm install phantomjs-polyfill`
+
 If using a transpiler, be sure to install it too. Traceur and Babel are supported:
 
 `npm install traceur`

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,14 @@ var initSystemjs = function (config) {
 		);
 	}
 
+	// system.js-0.16 uses Function.prototype.bind, which PhantomJS does not support.
+	if (config.browsers && config.browsers.indexOf('PhantomJS') !== -1) {
+		var phantomjsPolyfillPath = getDependencyPath('phantomjs-polyfill', '/bind-polyfill.js');
+		config.files.unshift(
+			createIncludePattern(phantomjsPolyfillPath)
+		);
+	}
+
 	// Adds file patterns from config.systemjs.files to config.files, set to be served but not included
 	if (systemjsConfig.files) {
 		systemjsConfig.files.forEach(function (filePath) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "karma": ">=0.9.0",
     "karma-firefox-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.4",
+    "phantomjs-polyfill": "0.0.1",
     "systemjs": "^0.15.0",
     "traceur": "^0.0.81",
     "babel": "^4.7.3"


### PR DESCRIPTION
PhantomJS does not support `Function.prototype.bind()`, which SystemJS now uses. We need to polyfill that before SystemJS is loaded in case we are using PhantomJS.