### PR TITLE
All multiple System.config calls

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -19,7 +19,7 @@ var readConfigFile = function(filePath) {
   var fileConfig = {};
   global.System = {
     config: function(cfg) {
-      fileConfig = cfg;
+      merge(cfg, fileConfig);
     }
   };
   // jshint evil:true

--- a/test/framework.spec.js
+++ b/test/framework.spec.js
@@ -47,6 +47,7 @@ describe('initSystemJs', function () {
     config.systemjs.configFile = 'test/system.conf.js';
     initSystemJs(config, logger);
     expect(config.client.systemjs.config.transpiler).toBe('babel');
+    expect(config.client.systemjs.config.baseURL).toBe('/');
   });
 
 	it('Adds the plugin adapter to the end of the files list', function () {

--- a/test/system.conf.js
+++ b/test/system.conf.js
@@ -2,3 +2,6 @@
 System.config({
   transpiler: 'babel'
 });
+System.config({
+  baseURL: '/'
+});


### PR DESCRIPTION
The config file generated by jspm can sometimes contain multiple `System.config` calls.