### PR TITLE
Make karma-systemjs work with es6-module-loader >= v0.16.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ var initSystemjs = function (config) {
 		mergeConfigs(readConfigFile(cfgPath), systemjsConfig.config);
 	}
 
-	var es6ModuleLoaderPath = getDependencyPath('es6-module-loader', '/../dist/es6-module-loader.src.js');
+	var es6ModuleLoaderPath = getDependencyPath('es6-module-loader', '/dist/es6-module-loader.src.js');
 	var systemjsPath = getDependencyPath('systemjs', '/system.src.js');
 
 	// Adds dependencies to start of config.files: es6-module-loader, and system.js

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "homepage": "https://github.com/rolaveric/karma-systemjs",
   "dependencies": {},
   "devDependencies": {
-    "es6-module-loader": "^0.15.0",
+    "es6-module-loader": "^0.16.5",
     "jasmine-core": "^2.1.3",
     "jasmine-node": "^1.14.5",
     "karma": ">=0.9.0",
     "karma-firefox-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.4",
     "phantomjs-polyfill": "0.0.1",
-    "systemjs": "^0.15.0",
+    "systemjs": "^0.16.7",
     "traceur": "^0.0.81",
     "babel": "^4.7.3"
   }


### PR DESCRIPTION
es6-module-loader v0.16.2 has removed the main entry point from package.json, which breaks resolving es6-module-loader.src.js. Update the getDependencyPath() reference to reflect this.