### PR TITLE
Fix case where baseURL is relative

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -83,7 +83,7 @@
       // Load SystemJS configuration from karma config
       // And update baseURL with '/base', where Karma serves files from
       if (karma.config.systemjs.config) {
-        karma.config.systemjs.config.baseURL = '/base' + (karma.config.systemjs.config.baseURL || '/');
+        karma.config.systemjs.config.baseURL = this.updatebaseURL(karma.config.systemjs.config.baseURL);
         System.config(karma.config.systemjs.config);
       } else {
         System.config({baseURL: '/base/'});

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -58,8 +58,12 @@
      * @returns {string}
      */
     updatebaseURL: function(originalBaseURL) {
-      if (originalBaseURL.indexOf('./') === 0) {
+      if (!originalBaseURL) {
+        return '/base/';
+      } else if (originalBaseURL.indexOf('./') === 0) {
         return originalBaseURL.replace('./', '/base/');
+      } else if (originalBaseURL.indexOf("/") !== 0) {
+        return '/base/' + originalBaseURL;
       } else {
         return '/base' + originalBaseURL;
       }

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -71,6 +71,9 @@ describe('karmaSystemjsAdapter()', function() {
   });
 
   describe('updatebaseURL()', function() {
+    it('Adds "/base" to the start of System.baseURL, after calling System.config()', function() {
+      expect(adapter.updatebaseURL('app')).toBe('/base/app');
+    });
 
     it('Adds "/base" to the start of System.baseURL, after calling System.config()', function() {
       expect(adapter.updatebaseURL('/app/')).toBe('/base/app/');


### PR DESCRIPTION
When the baseURL is a relative path (e.g. the web-root is not the repo-root), the `base` path is not inserted correctly.

e.g.: baseURL: "src" => baseURL: "/basesrc" // instead of "/base/src"

This PR fix that issue by adding that case in updatebaseURL and use it during run().