### PR TITLE
Override base url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,12 @@ var initSystemjs = function(config) {
   if (kSystemjsConfig.configFile) {
     // Load it, and merge it with the config
     var cfgPath = basePath + kSystemjsConfig.configFile;
+  
+    var kbaseURL = kSystemjsConfig.config.baseURL;
     _.merge(kSystemjsConfig.config, readConfigFile(cfgPath));
+    if (kbaseURL) {
+      kSystemjsConfig.config.baseURL = kbaseURL;
+    }
   }
 
   // Resolve the paths for es6-module-loader and systemjs

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -120,4 +120,11 @@ describe('initSystemJs', function() {
       config: 123
     });
   });
+
+  it('override baseURL in config', function() {
+    config.systemjs.config = { baseURL: "abc" };
+    config.systemjs.configFile = 'test/systemWithBaseURL.conf.js';
+    initSystemJs(config);
+    expect(config.systemjs.config.baseURL).toEqual('abc');
+  });  
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -23,7 +23,7 @@ describe('initSystemJs', function() {
   it('Adds Babel instead of Traceur if the transpiler option is set', function() {
     config.systemjs.config = {transpiler: 'babel'};
     initSystemJs(config);
-    expect(config.files[0].pattern).toMatch(/\/babel-core\/.*?\/browser\.js$/);
+    expect(config.files[0].pattern).toMatch(/[\/\\]babel-core\/.*?\/browser\.js$/);
     expect(config.files[1].pattern).toMatch(/\/es6-module-loader\.src\.js$/);
     expect(config.files[2].pattern).toMatch(/\/system-polyfills\.js$/);
     expect(config.files[3].pattern).toMatch(/\/system\.src\.js$/);
@@ -32,7 +32,8 @@ describe('initSystemJs', function() {
   it('Adds Typescript instead of Traceur if the transpiler option is set', function() {
     config.systemjs.config = {transpiler: 'typescript'};
     initSystemJs(config);
-    expect(config.files[0].pattern).toMatch(/\/typescript\/.*?\/typescript\.js$/);
+    console.log(config.files[1].pattern);
+    expect(config.files[0].pattern).toMatch(/[\/\\]typescript[\/\\].*?[\/\\]typescript\.js$/);
     expect(config.files[1].pattern).toMatch(/\/es6-module-loader\.src\.js$/);
     expect(config.files[2].pattern).toMatch(/\/system-polyfills\.js$/);
     expect(config.files[3].pattern).toMatch(/\/system\.src\.js$/);

--- a/test/systemWithBaseURL.conf.js
+++ b/test/systemWithBaseURL.conf.js
@@ -1,0 +1,5 @@
+// Used for testing config loading
+System.config({
+  baseURL: "lib",
+  transpiler: 'babel'
+});


### PR DESCRIPTION
Add the ability to override baseURL in karma.systemjs.config to support case when the
source code base path and karma base path are different.

See the `side-js` sample in
[https://github.com/unional/karma-systemjs-sample](https://github.com/unional/karma-systemjs-sample).

That code needs override-baseURL and relative-URL (already merged) PR to work