### PR TITLE
karma.config takes precedence over config file.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -118,13 +118,13 @@ var initSystemjs = function(config) {
   // If there's an external SystemJS configuration file...
   if (kSystemjsConfig.configFile) {
     // Load it, and merge it with the config
+    // karma-systemjs.config should take precedence over external SystemJS configuration file
     var cfgPath = basePath + kSystemjsConfig.configFile;
-  
-    var kbaseURL = kSystemjsConfig.config.baseURL;
-    _.merge(kSystemjsConfig.config, readConfigFile(cfgPath));
-    if (kbaseURL) {
-      kSystemjsConfig.config.baseURL = kbaseURL;
-    }
+    var kConfig = readConfigFile(cfgPath);
+    
+    _.merge(kConfig, kSystemjsConfig.config);
+
+    kSystemjsConfig.config = kConfig;
   }
 
   // Resolve the paths for es6-module-loader and systemjs

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -63,6 +63,18 @@ describe('initSystemJs', function() {
     expect(config.files[3].pattern).toMatch(/mySystem\.js$/);
   });
 
+  it('Overrides paths provided by the external SystemJS config file with systemjs.config.paths', function() {
+    config.systemjs.config = {
+      paths: {
+        'module-a': 'to-patched-version.js'
+      }
+    };
+    config.systemjs.configFile = 'test/system.conf.js';
+    initSystemJs(config);
+
+    expect(config.client.systemjs.config.paths['module-a']).toEqual('to-patched-version.js');
+  });
+
   it('Does NOT adds file pattern for the SystemJS config file - only gets read and passed to adapter', function() {
     config.systemjs.configFile = 'test/system.conf.js';
     initSystemJs(config);

--- a/test/system.conf.js
+++ b/test/system.conf.js
@@ -1,4 +1,7 @@
 // Used for testing config loading
 System.config({
-  transpiler: 'babel'
+  transpiler: 'babel',
+  paths: {
+  	'module-a': 'to-actual-src.js'
+  }
 });


### PR DESCRIPTION
Similar to what used to only happen for `baseURL`, overall karma-systemjs.config should take precedence over external SystemJS configuration file. This becomes crucial when an existing path needs to be overwritten by karma-systemjs config. @rolaveric what do you think? cc: @newduke