### PR TITLE
Create a pattern matching base or absolute paths

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -114,8 +114,11 @@ var processIncludedPatterns = function(fileList, basePath) {
   return _.map(included, function(file) {
     // Rather than make Minimatch available in the browser,
     // it's simpler to use it within Karma and extract the RegExps as strings.
-    // Also take into account the '/base' path that Karma serves files from
-    var regexString = (new Minimatch('/base' + file.pattern.replace(basePath, ''))).makeRe().toString();
+    // Also take into account the '/base' or '/absolute' path that Karma serves files from
+    var path = !basePath || file.pattern.indexOf(basePath) == 0 ?
+        '/base' + file.pattern.replace(basePath, '') :
+        '/absolute' + file.pattern;
+    var regexString = (new Minimatch(path)).makeRe().toString();
     return regexString.substring(1, regexString.length - 1); // Remove the "/" from the start and end, so it'll fit into 'new RegExp()'
   });
 };

--- a/test/framework.spec.js
+++ b/test/framework.spec.js
@@ -219,6 +219,15 @@ describe('initSystemJs', function() {
     initSystemJs(config);
     var expected = (new Minimatch('/base/app/**/*.js')).makeRe().toString();
     expect(config.client.systemjs.importPatterns)
+    .toEqual([expected.substring(1, expected.length - 1)]);
+  });
+
+  it('Creates importPatterns for absolute paths', function() {
+    config.basePath = '/test'
+    config.files = [{pattern: '/app/**/*.js', included: true}];
+    initSystemJs(config);
+    var expected = (new Minimatch('/absolute/app/**/*.js')).makeRe().toString();
+    expect(config.client.systemjs.importPatterns)
       .toEqual([expected.substring(1, expected.length - 1)]);
   });
 });


### PR DESCRIPTION
Karma will serve files under basePath under '/base', but files outside
this path under '/absolute'. Create patterns for either type of file.
Closes issue #51