### PR TITLE
Relocate absolute paths in SystemJS config file

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -150,6 +150,17 @@ var initSystemjs = function(config) {
     var cfgPath = basePath + kSystemjsConfig.configFile;
     var kConfig = readConfigFile(cfgPath);
 
+    // Absolute paths for modules should be moved to /base, where Karma serves them
+    ['map', 'paths'].forEach(function(cfgKey) {
+      if (typeof kConfig[cfgKey] === 'object') {
+        Object.keys(kConfig[cfgKey]).forEach(function(module) {
+          if (kConfig[cfgKey][module][0] === '/') {
+            kConfig[cfgKey][module] = '/base' + kConfig[cfgKey][module];
+          }
+        });
+      }
+    });
+
     _.merge(kConfig, kSystemjsConfig.config);
 
     kSystemjsConfig.config = kConfig;

--- a/test/framework.spec.js
+++ b/test/framework.spec.js
@@ -214,6 +214,13 @@ describe('initSystemJs', function() {
     expect(config.systemjs.config.baseURL).toEqual('abc');
   });
 
+  it('Relocates absolute paths in config', function() {
+    config.systemjs.configFile = 'test/systemWithAbsolutePath.conf.js';
+    initSystemJs(config);
+    expect(config.systemjs.config.map['jquery']).toEqual('/base/thirdparty/jquery.js');
+    expect(config.systemjs.config.map['module-a']).toEqual('to-actual-src.js');
+  });
+
   it('Attaches importPatterns to client.systemjs', function() {
     config.files = [{pattern: '/app/**/*.js', included: true}];
     initSystemJs(config);

--- a/test/systemWithAbsolutePath.conf.js
+++ b/test/systemWithAbsolutePath.conf.js
@@ -1,0 +1,7 @@
+System.config({
+  baseURL: '/app',
+  map: {
+  	'module-a': 'to-actual-src.js',
+    'jquery': '/thirdparty/jquery.js',
+  }
+});


### PR DESCRIPTION
Absolute paths are not affected by changing baseURL, so they must all
be rewritten to be under /base. Closes issue #53