### PR TITLE
fix: missing adapter when using includeFiles

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -225,18 +225,15 @@ var initSystemjs = function(config) {
 
   // Add file patterns to always be included back into files
   if (kSystemjsConfig.includeFiles) {
-    kSystemjsConfig.includeFiles.forEach(function(pathOrPattern) {
-      
-	  var fileToInclude;
-	  
-	  if (typeof pathOrPattern === 'object') {
-        fileToInclude = pathOrPattern;
-      } else {
-		fileToInclude = createIncludePattern(basePath + pathOrPattern);
-	  }
-	  
-	  config.files.push(fileToInclude);
+    var filesToInclude = kSystemjsConfig.includeFiles.map(function(pathOrPattern) {
+  	if (typeof pathOrPattern === 'object') {
+           return pathOrPattern;
+      	} else {
+	   return createIncludePattern(basePath + pathOrPattern);
+  	}
     });
+    
+    config.files.unshift(fileToInclude);
   }
 
   // Adds karma-systemjs adapter.js to end of config.files

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -225,13 +225,18 @@ var initSystemjs = function(config) {
 
   // Add file patterns to always be included back into files
   if (kSystemjsConfig.includeFiles) {
-    var includedPatterns = kSystemjsConfig.includeFiles.map(function(pathOrPattern) {
-      if (typeof pathOrPattern === 'object') {
-        return pathOrPattern;
-      }
-      return createIncludePattern(basePath + pathOrPattern);
+    kSystemjsConfig.includeFiles.forEach(function(pathOrPattern) {
+      
+	  var fileToInclude;
+	  
+	  if (typeof pathOrPattern === 'object') {
+        fileToInclude = pathOrPattern;
+      } else {
+		fileToInclude = createIncludePattern(basePath + pathOrPattern);
+	  }
+	  
+	  config.files.push(fileToInclude);
     });
-    config.files = includedPatterns.concat(config.files);
   }
 
   // Adds karma-systemjs adapter.js to end of config.files

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -233,7 +233,7 @@ var initSystemjs = function(config) {
   	}
     });
     
-    config.files.unshift(fileToInclude);
+    config.files.unshift(filesToInclude);
   }
 
   // Adds karma-systemjs adapter.js to end of config.files


### PR DESCRIPTION
This pull request fixes issue #56 .

The config.files array appears to be referenced elsewhere. Thus we need to use the same array instead of creating a new one.