### PR TITLE
fix: useBundles option is not respected and was set incorrectly for systemjs

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -158,13 +158,13 @@
           karma.config.systemjs.config = JSON.parse(karma.config.systemjs.config);
 
           karma.config.systemjs.config.baseURL = adapter.updateBaseURL(karma.config.systemjs.config.baseURL);
-          System.config(karma.config.systemjs.config);
 
           // Exclude bundle configurations if useBundles option is not specified
           if (!karma.config.systemjs.useBundles) {
-            System.bundles = [];
+            karma.config.systemjs.config.bundles = [];
           }
 
+          System.config(karma.config.systemjs.config);
         } else {
           System.config({baseURL: '/base/'});
         }

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -265,7 +265,8 @@ var initSystemjs = function(config) {
     // https://github.com/rolaveric/karma-systemjs/issues/44
     config: JSON.stringify(kSystemjsConfig.config),
     importPatterns: importPatterns,
-    strictImportSequence: kSystemjsConfig.strictImportSequence
+    strictImportSequence: kSystemjsConfig.strictImportSequence,
+    useBundles: kSystemjsConfig.useBundles
   };
 };
 initSystemjs.$inject = ['config'];

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -148,7 +148,7 @@ describe('karmaSystemjsAdapter()', function() {
       karma.config.systemjs.config = '{"key": "value"}';
       adapter.run(karma, System, Promise);
       karma.loaded();
-      expect(System.config).toHaveBeenCalledWith({key: 'value', baseURL: '/base/'});
+      expect(System.config).toHaveBeenCalledWith({key: 'value', baseURL: '/base/', bundles: []});
     });
 
     it('Only calls System.config() to set baseURL, if no config set', function() {


### PR DESCRIPTION
The method for setting bundles changed May 2015 here (tagged systemjs@0.17):
https://github.com/systemjs/systemjs/commit/2141c64b31f2b4b35f9089c2f306049d334c652e

Closes #91, #90 